### PR TITLE
Add analytics integration and responsive tweaks

### DIFF
--- a/src/app/analytics.service.ts
+++ b/src/app/analytics.service.ts
@@ -1,0 +1,50 @@
+import { Injectable } from '@angular/core';
+import { Router, NavigationEnd } from '@angular/router';
+import { filter } from 'rxjs/operators';
+import { environment } from '../environments/environment';
+
+/**
+ * Simple Google Analytics integration service.
+ * Loads gtag script and tracks page views on route changes.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class AnalyticsService {
+  private initialized = false;
+
+  constructor(private router: Router) {}
+
+  initialize(): void {
+    if (this.initialized || !environment.analyticsTrackingId) {
+      return;
+    }
+    this.initialized = true;
+
+    const gaScript = document.createElement('script');
+    gaScript.async = true;
+    gaScript.src = `https://www.googletagmanager.com/gtag/js?id=${environment.analyticsTrackingId}`;
+    document.head.appendChild(gaScript);
+
+    const script = document.createElement('script');
+    script.innerHTML = `
+      window.dataLayer = window.dataLayer || [];
+      function gtag(){dataLayer.push(arguments);}
+      gtag('js', new Date());
+      gtag('config', '${environment.analyticsTrackingId}');
+    `;
+    document.head.appendChild(script);
+
+    this.router.events
+      .pipe(filter((e): e is NavigationEnd => e instanceof NavigationEnd))
+      .subscribe(e => this.trackPage(e.urlAfterRedirects));
+  }
+
+  trackPage(url: string): void {
+    if ((window as any).gtag) {
+      (window as any).gtag('config', environment.analyticsTrackingId, {
+        page_path: url
+      });
+    }
+  }
+}

--- a/src/app/app.component.html
+++ b/src/app/app.component.html
@@ -1,9 +1,9 @@
-<div class="container-scroller">
+<div class="container-scroller" fxLayout="column" fxLayoutFill>
   <app-navbar *ngIf="showNavbar"></app-navbar>
-  <div class="container-fluid page-body-wrapper">
+  <div class="container-fluid page-body-wrapper" fxLayout="row" fxLayout.lt-md="column">
 
     <div class="main-panel" [ngClass]="{ 'main-panel-only' : !showSidebar }">
-      <div class="content-wrapper">
+      <div class="content-wrapper" fxFlex>
         <app-spinner *ngIf="isLoading"></app-spinner>
         <div contentAnimate *ngIf="!isLoading" class="h-100">
           <router-outlet></router-outlet>

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, isDevMode, HostListener } from '@angular/core';
+import { Component, OnInit, isDevMode, HostListener, ChangeDetectionStrategy } from '@angular/core';
 import { Router, NavigationEnd, NavigationStart, RouteConfigLoadStart, RouteConfigLoadEnd } from '@angular/router';
 import {
   SwPush,
@@ -9,11 +9,13 @@ import {
 } from '@angular/service-worker';
 import { PUBLIC_VAPID_KEY_OF_SERVER } from './app.constants';
 import { NotificationService } from './notifications.service';
+import { AnalyticsService } from './analytics.service';
+import { BreakpointObserver, Breakpoints } from '@angular/cdk/layout';
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.scss']
- 
+  styleUrls: ['./app.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
 })
 export class AppComponent implements OnInit {
   notificationData = '{}';
@@ -23,8 +25,14 @@ export class AppComponent implements OnInit {
   showSidebar = true;
   showNavbar = true;
   isLoading: boolean;
-  constructor(private router: Router, private updateService: SwUpdate,
-    private pushService: SwPush, private notificationService: NotificationService) {
+  constructor(private router: Router,
+    private updateService: SwUpdate,
+    private pushService: SwPush,
+    private notificationService: NotificationService,
+    private analytics: AnalyticsService,
+    private breakpointObserver: BreakpointObserver) {
+    this.breakpointObserver.observe([Breakpoints.Handset])
+      .subscribe(result => this.showSidebar = !result.matches);
     // Removing Sidebar, Navbar, Footer for Documentation, Error and Auth pages
     router.events.forEach((event) => {
       if (event instanceof NavigationStart) {
@@ -58,6 +66,7 @@ export class AppComponent implements OnInit {
     });
   }
   ngOnInit() {
+    this.analytics.initialize();
     this.getScreenWidth = window.innerWidth;
     this.getScreenHeight = window.innerHeight;
     if (isDevMode()) {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,5 +1,7 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { LayoutModule } from '@angular/cdk/layout';
 import { AppRoutingModule } from './app-routing.module';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { ServiceWorkerModule } from '@angular/service-worker';
@@ -22,6 +24,8 @@ import { SharedModule } from './shared/shared.module';
     AppRoutingModule,
     BrowserModule,
     BrowserAnimationsModule,
+    FlexLayoutModule,
+    LayoutModule,
     SharedModule,
     ServiceWorkerModule.register('ngsw-worker.js', {
       enabled: environment.production,

--- a/src/environments/environment.prod.ts
+++ b/src/environments/environment.prod.ts
@@ -1,4 +1,8 @@
 export const environment = {
   production: true,
- };
+  /**
+   * Google Analytics tracking ID used by AnalyticsService.
+   */
+  analyticsTrackingId: 'G-XXXXXXX'
+};
 

--- a/src/environments/environment.ts
+++ b/src/environments/environment.ts
@@ -4,7 +4,11 @@
 
 export const environment = {
   production: false,
-
+  /**
+   * Google Analytics tracking ID used by AnalyticsService.
+   * Replace with your own ID when deploying.
+   */
+  analyticsTrackingId: 'G-XXXXXXX'
 };
 
 /*


### PR DESCRIPTION
## Summary
- integrate Google Analytics using a new service
- add BreakpointObserver to collapse sidebar on mobile
- enhance layout using Angular Flex-Layout
- expose new `analyticsTrackingId` property in environments

## Testing
- `npm run lint` *(fails: ESLint couldn't find configuration)*
- `npx ng test --watch=false` *(fails: could not determine executable to run)*
- `npx ng build --configuration=production` *(fails: could not determine executable to run)*

------
https://chatgpt.com/codex/tasks/task_e_6842d93d0e84832c955e9ba301afa2e0