### PR TITLE
Add market overview chart

### DIFF
--- a/src/app/core/services/data-api.service.ts
+++ b/src/app/core/services/data-api.service.ts
@@ -52,9 +52,10 @@ export class DataApiService {
   }
 
   private setBaseUrl(): void {
-    this.baseUrl = window.location.hostname === "localhost" 
-      ? "http://localhost:9999"
-      : "https://stockinsights.netlify.app";
+    // Use the API URL defined in the environment configuration so
+    // that the service works in both local development and the
+    // deployed Netlify environment.
+    this.baseUrl = environment.apiUrl;
   }
 
   private initializeWebSocket(): void {
@@ -285,6 +286,16 @@ export class DataApiService {
 
   getNtGlobal(): Observable<GlobalMarketData[]> {
     return this.get('/api/nt/global');
+  }
+
+  /**
+   * Fetch overall market statistics such as index levels and
+   * advances/declines. The API is served via the Netlify function
+   * defined in `netlify/functions/api.ts` under the
+   * `market/overview` route.
+   */
+  getMarketOverview(): Observable<any> {
+    return this.get('/api/market/overview');
   }
 
   getTlBuildup(tlid: string): Observable<any> {

--- a/src/app/features/dashboard/components/market-overview-chart/market-overview-chart.component.html
+++ b/src/app/features/dashboard/components/market-overview-chart/market-overview-chart.component.html
@@ -1,0 +1,7 @@
+<div class="chart-container">
+  <canvas baseChart
+          [data]="chartData"
+          [options]="chartOptions"
+          chartType="bar">
+  </canvas>
+</div>

--- a/src/app/features/dashboard/components/market-overview-chart/market-overview-chart.component.scss
+++ b/src/app/features/dashboard/components/market-overview-chart/market-overview-chart.component.scss
@@ -1,0 +1,4 @@
+.chart-container {
+  position: relative;
+  height: 300px;
+}

--- a/src/app/features/dashboard/components/market-overview-chart/market-overview-chart.component.ts
+++ b/src/app/features/dashboard/components/market-overview-chart/market-overview-chart.component.ts
@@ -1,0 +1,50 @@
+import { Component, OnInit, ChangeDetectionStrategy } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { ChartConfiguration, ChartType } from 'chart.js';
+import { NgChartsModule } from 'ng2-charts';
+import { DataApiService } from '../../../../core/services/data-api.service';
+
+@Component({
+  selector: 'app-market-overview-chart',
+  standalone: true,
+  imports: [CommonModule, NgChartsModule],
+  templateUrl: './market-overview-chart.component.html',
+  styleUrls: ['./market-overview-chart.component.scss'],
+  changeDetection: ChangeDetectionStrategy.OnPush
+})
+export class MarketOverviewChartComponent implements OnInit {
+  chartData: ChartConfiguration<'bar'>['data'] = { labels: [], datasets: [] };
+  chartOptions: ChartConfiguration<'bar'>['options'] = {
+    responsive: true,
+    maintainAspectRatio: false
+  };
+
+  constructor(private api: DataApiService) {}
+
+  ngOnInit(): void {
+    this.api.getMarketOverview().subscribe({
+      next: (data) => this.buildChart(data),
+      error: (err) => console.error('Failed to load market overview', err)
+    });
+  }
+
+  private buildChart(data: any): void {
+    if (!data) { return; }
+
+    const labels: string[] = [];
+    const values: number[] = [];
+
+    Object.keys(data).forEach(key => {
+      const value = Number(data[key]);
+      if (!isNaN(value)) {
+        labels.push(key);
+        values.push(value);
+      }
+    });
+
+    this.chartData = {
+      labels,
+      datasets: [{ data: values, label: 'Index Value' }]
+    };
+  }
+}

--- a/src/app/features/dashboard/dashboard.component.html
+++ b/src/app/features/dashboard/dashboard.component.html
@@ -5,6 +5,9 @@
       <mat-grid-tile [colspan]="2" [rowspan]="1">
         <app-market-overview class="widget"></app-market-overview>
       </mat-grid-tile>
+      <mat-grid-tile [colspan]="2" [rowspan]="1">
+        <app-market-overview-chart class="widget"></app-market-overview-chart>
+      </mat-grid-tile>
 
       <!-- Watchlist -->
       <mat-grid-tile [colspan]="2" [rowspan]="1">

--- a/src/app/features/dashboard/dashboard.component.ts
+++ b/src/app/features/dashboard/dashboard.component.ts
@@ -10,6 +10,7 @@ import { map } from 'rxjs/operators';
 
 // Import widget components
 import { MarketOverviewComponent } from './components/market-overview/market-overview.component';
+import { MarketOverviewChartComponent } from './components/market-overview-chart/market-overview-chart.component';
 import { WatchlistWidgetComponent } from './components/watchlist-widget/watchlist-widget.component';
 import { NewsWidgetComponent } from './components/news-widget/news-widget.component';
 import { PortfolioWidgetComponent } from './components/portfolio-widget/portfolio-widget.component';
@@ -27,6 +28,7 @@ import { PortfolioWidgetComponent } from './components/portfolio-widget/portfoli
     MatIconModule,
     MatButtonModule,
     MarketOverviewComponent,
+    MarketOverviewChartComponent,
     WatchlistWidgetComponent,
     NewsWidgetComponent,
     PortfolioWidgetComponent


### PR DESCRIPTION
## Summary
- rely on `environment.apiUrl` for `DataApiService`
- expose `getMarketOverview` to fetch market stats
- add `MarketOverviewChartComponent` using ng2-charts
- show the chart on the dashboard page

## Testing
- `npm test` *(fails: ng not found)*
- `npm run lint` *(fails: ESLint couldn't find configuration)*

------
https://chatgpt.com/codex/tasks/task_e_684376213e0c832cb2cb9c65a12ce370